### PR TITLE
just to see the diff

### DIFF
--- a/apps/frontend/src/components/modals/ConnectWallet/ConnectWallet.tsx
+++ b/apps/frontend/src/components/modals/ConnectWallet/ConnectWallet.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import './ConnectWallet.scss';
 import { useContext, useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -18,13 +16,15 @@ import { CloseSVG } from '../../../svgs/Close';
 import { copyTextToClipboard } from '../../../utilities/data-formatters';
 import { ConnectWalletFields } from '../../../types/app-config.type';
 import logger from '../../../services/logger.service';
+import useHttp from '../../../hooks/use-http';
 
 const ConnectWallet = () => {
   const appCtx = useContext(AppContext);
+  const { createInvoiceRune } = useHttp();
   const [networkTypes, setNetworkTypes] = useState<string[]>(['LN Message', 'LN Message (Tor)']);
   const [selNetwork, setSelNetwork] = useState('LN Message');
   const [connectUrl, setConnectUrl] = useState('');
-  const initialConnectValues: ConnectWalletFields = { port: { title: 'Websocket Port', field: 'WS_PORT' }, host: { title: 'CLN Host', field: 'DEVICE_DOMAIN_NAME' }, macaroon: { title: 'Rune', field: 'COMMANDO_RUNE' }, connectUrl: { title: 'Lnmessage URL', field: '' }, clientCert: { title: 'Client Cert', field: '' }, caCert: { title: 'CA Cert', field: '' } };
+  const initialConnectValues: ConnectWalletFields = { port: { title: 'Websocket Port', field: 'WS_PORT' }, host: { title: 'CLN Host', field: 'DEVICE_DOMAIN_NAME' }, macaroon: { title: 'Rune', field: 'COMMANDO_RUNE' }, invoiceRune: { title: 'Invoice Rune', field: "INVOICE_RUNE" }, connectUrl: { title: 'Lnmessage URL', field: '' }, clientCert: { title: 'Client Cert', field: '' }, caCert: { title: 'CA Cert', field: '' } };
   const [connectValues, setConnectValues] = useState(initialConnectValues);
 
   useEffect(() => {
@@ -44,6 +44,9 @@ const ConnectWallet = () => {
     setNetworkTypes(newNetworkTypes);
     if (selNetwork === 'LN Message') {
       setConnectUrl('ln-message://' + appCtx.walletConnect.DEVICE_DOMAIN_NAME + ':' + appCtx.walletConnect.WS_PORT + '?rune=' + appCtx.walletConnect.COMMANDO_RUNE);
+    }
+    if (appCtx.authStatus.isAuthenticated && !appCtx.walletConnect.INVOICE_RUNE) {
+      createInvoiceRune();
     }
   }, [appCtx, selNetwork]);
 
@@ -67,6 +70,9 @@ const ConnectWallet = () => {
           break;
       case 'Macaroon':
         textToCopy = appCtx.walletConnect.REST_MACAROON || '';
+        break;
+      case 'Invoice Rune':
+        textToCopy = appCtx.walletConnect.INVOICE_RUNE || '';
         break;
       case 'Client Key':
         textToCopy = appCtx.walletConnect.CLIENT_KEY || '';
@@ -96,37 +102,37 @@ const ConnectWallet = () => {
     setSelNetwork(event.target.id);
     switch (event.target.id) {
       case 'LN Message':
-        setConnectValues({ port: { title: 'Websocket Port', field: 'WS_PORT' }, host: { title: 'CLN Host', field: 'DEVICE_DOMAIN_NAME' }, macaroon: { title: 'Rune', field: 'COMMANDO_RUNE' }, connectUrl: { title: 'Lnmessage URL', field: '' }, clientCert: { title: 'Client Cert', field: '' }, caCert: { title: 'CA Cert', field: '' } });
+        setConnectValues({ port: { title: 'Websocket Port', field: 'WS_PORT' }, host: { title: 'CLN Host', field: 'DEVICE_DOMAIN_NAME' }, macaroon: { title: 'Rune', field: 'COMMANDO_RUNE' }, invoiceRune: { title: 'Invoice Rune', field: "INVOICE_RUNE" }, connectUrl: { title: 'Lnmessage URL', field: '' }, clientCert: { title: 'Client Cert', field: '' }, caCert: { title: 'CA Cert', field: '' } });
         setConnectUrl('ln-message://' + appCtx.walletConnect.DEVICE_DOMAIN_NAME + ':' + appCtx.walletConnect.WS_PORT + '?rune=' + appCtx.walletConnect.COMMANDO_RUNE);
         break;
 
       case 'LN Message (Tor)':
-        setConnectValues({ port: { title: 'Websocket Port', field: 'WS_PORT' }, host: { title: 'CLN Host', field: 'TOR_DOMAIN_NAME' }, macaroon: { title: 'Rune', field: 'COMMANDO_RUNE' }, connectUrl: { title: 'Lnmessage URL', field: '' }, clientCert: { title: 'Client Cert', field: '' }, caCert: { title: 'CA Cert', field: '' } });
+        setConnectValues({ port: { title: 'Websocket Port', field: 'WS_PORT' }, host: { title: 'CLN Host', field: 'TOR_DOMAIN_NAME' }, macaroon: { title: 'Rune', field: 'COMMANDO_RUNE' }, invoiceRune: { title: 'Invoice Rune', field: "INVOICE_RUNE" }, connectUrl: { title: 'Lnmessage URL', field: '' }, clientCert: { title: 'Client Cert', field: '' }, caCert: { title: 'CA Cert', field: '' } });
         setConnectUrl('ln-message://' + appCtx.walletConnect.TOR_DOMAIN_NAME + ':' + appCtx.walletConnect.WS_PORT + '?rune=' + appCtx.walletConnect.COMMANDO_RUNE);
         break;
 
       case 'REST':
-        setConnectValues({ port: { title: 'REST Port', field: 'REST_PORT' }, host: { title: 'CLN Host', field: 'LOCAL_HOST' }, macaroon: { title: 'Macaroon', field: 'REST_MACAROON' }, connectUrl: { title: 'REST URL', field: '' }, clientCert: { title: 'Client Cert', field: '' }, caCert: { title: 'CA Cert', field: '' } });
+        setConnectValues({ port: { title: 'REST Port', field: 'REST_PORT' }, host: { title: 'CLN Host', field: 'LOCAL_HOST' }, macaroon: { title: 'Macaroon', field: 'REST_MACAROON' }, invoiceRune: { title: 'Invoice Rune', field: "INVOICE_RUNE" }, connectUrl: { title: 'REST URL', field: '' }, clientCert: { title: 'Client Cert', field: '' }, caCert: { title: 'CA Cert', field: '' } });
         setConnectUrl('c-lightning-rest://' + appCtx.walletConnect.LOCAL_HOST + ':' + appCtx.walletConnect.REST_PORT + '?macaroon=' + appCtx.walletConnect.REST_MACAROON + '&protocol=http');
         break;
 
       case 'REST (Tor)':
-        setConnectValues({ port: { title: 'REST Port', field: 'REST_PORT' }, host: { title: 'CLN Host', field: 'TOR_HOST' }, macaroon: { title: 'Macaroon', field: 'REST_MACAROON' }, connectUrl: { title: 'REST URL', field: '' }, clientCert: { title: 'Client Cert', field: '' }, caCert: { title: 'CA Cert', field: '' } });
+        setConnectValues({ port: { title: 'REST Port', field: 'REST_PORT' }, host: { title: 'CLN Host', field: 'TOR_HOST' }, macaroon: { title: 'Macaroon', field: 'REST_MACAROON' }, invoiceRune: { title: 'Invoice Rune', field: "INVOICE_RUNE" }, connectUrl: { title: 'REST URL', field: '' }, clientCert: { title: 'Client Cert', field: '' }, caCert: { title: 'CA Cert', field: '' } });
         setConnectUrl('c-lightning-rest://' + appCtx.walletConnect.TOR_HOST + ':' + appCtx.walletConnect.REST_PORT + '?macaroon=' + appCtx.walletConnect.REST_MACAROON + '&protocol=http');
         break;
   
       case 'gRPC':
-        setConnectValues({ port: { title: 'gRPC Port', field: 'GRPC_PORT' }, host: { title: 'CLN Host', field: 'DEVICE_DOMAIN_NAME' }, macaroon: { title: 'Client Key', field: 'CLIENT_KEY' }, connectUrl: { title: 'gRPC URL', field: '' }, clientCert: { title: 'Client Cert', field: 'CLIENT_CERT' }, caCert: { title: 'CA Cert', field: 'CA_CERT' } });
+        setConnectValues({ port: { title: 'gRPC Port', field: 'GRPC_PORT' }, host: { title: 'CLN Host', field: 'DEVICE_DOMAIN_NAME' }, macaroon: { title: 'Client Key', field: 'CLIENT_KEY' }, invoiceRune: { title: 'Invoice Rune', field: "INVOICE_RUNE" }, connectUrl: { title: 'gRPC URL', field: '' }, clientCert: { title: 'Client Cert', field: 'CLIENT_CERT' }, caCert: { title: 'CA Cert', field: 'CA_CERT' } });
         setConnectUrl('cln-grpc://' + appCtx.walletConnect.DEVICE_DOMAIN_NAME + ':' + appCtx.walletConnect.GRPC_PORT + '?clientkey=' + appCtx.walletConnect.CLIENT_KEY + '&clientCert=' + appCtx.walletConnect.CLIENT_CERT + '&caCert=' + appCtx.walletConnect.CA_CERT);
         break;
   
       case 'gRPC (Tor)':
-        setConnectValues({ port: { title: 'gRPC Port', field: 'GRPC_PORT' }, host: { title: 'CLN Host', field: 'TOR_DOMAIN_NAME' }, macaroon: { title: 'Client Key', field: 'CLIENT_KEY' }, connectUrl: { title: 'gRPC URL', field: '' }, clientCert: { title: 'Client Cert', field: 'CLIENT_CERT' }, caCert: { title: 'CA Cert', field: 'CA_CERT' } });
+        setConnectValues({ port: { title: 'gRPC Port', field: 'GRPC_PORT' }, host: { title: 'CLN Host', field: 'TOR_DOMAIN_NAME' }, macaroon: { title: 'Client Key', field: 'CLIENT_KEY' }, invoiceRune: { title: 'Invoice Rune', field: "INVOICE_RUNE" }, connectUrl: { title: 'gRPC URL', field: '' }, clientCert: { title: 'Client Cert', field: 'CLIENT_CERT' }, caCert: { title: 'CA Cert', field: 'CA_CERT' } });
         setConnectUrl('cln-grpc://' + appCtx.walletConnect.TOR_DOMAIN_NAME + ':' + appCtx.walletConnect.GRPC_PORT + '?clientkey=' + appCtx.walletConnect.CLIENT_KEY + '&clientCert=' + appCtx.walletConnect.CLIENT_CERT);
         break;
 
       default:
-        setConnectValues({ port: { title: 'Websocket Port', field: 'WS_PORT' }, host: { title: 'CLN Host', field: 'DEVICE_DOMAIN_NAME' }, macaroon: { title: 'Rune', field: 'COMMANDO_RUNE' }, connectUrl: { title: 'Lnmessage URL', field: '' }, clientCert: { title: 'Client Cert', field: '' }, caCert: { title: 'CA Cert', field: '' } });
+        setConnectValues({ port: { title: 'Websocket Port', field: 'WS_PORT' }, host: { title: 'CLN Host', field: 'DEVICE_DOMAIN_NAME' }, macaroon: { title: 'Rune', field: 'COMMANDO_RUNE' }, invoiceRune: { title: 'Invoice Rune', field: "INVOICE_RUNE" },connectUrl: { title: 'Lnmessage URL', field: '' }, clientCert: { title: 'Client Cert', field: '' }, caCert: { title: 'CA Cert', field: '' } });
         setConnectUrl('ln-message://' + appCtx.walletConnect.DEVICE_DOMAIN_NAME + ':' + appCtx.walletConnect.WS_PORT + '?rune=' + appCtx.walletConnect.COMMANDO_RUNE);
         break;
     }
@@ -227,6 +233,25 @@ const ConnectWallet = () => {
                 />
                 <InputGroup.Text id={connectValues.macaroon.title} className='form-control-addon form-control-addon-right' onClick={copyHandler}>
                   <CopySVG id={connectValues.macaroon.title} />
+                </InputGroup.Text>
+              </InputGroup>
+            </Col>
+          </Row>
+          <Row className='d-flex align-items-start justify-content-center'>
+            <Col xs={12}>
+              <Form.Label className='text-light'>{connectValues.invoiceRune.title}</Form.Label>
+              <InputGroup className='mb-3'>
+                <Form.Control 
+                  onClick={copyHandler}
+                  id={connectValues.invoiceRune.title}
+                  value={appCtx.walletConnect[connectValues.invoiceRune.field]}
+                  aria-label={appCtx.walletConnect[connectValues.invoiceRune.field]}
+                  aria-describedby='copy-addon-macaroon'
+                  className='form-control-left'
+                  readOnly
+                />
+                <InputGroup.Text id={connectValues.invoiceRune.title} className='form-control-addon form-control-addon-right' onClick={copyHandler}>
+                  <CopySVG id={connectValues.invoiceRune.title} />
                 </InputGroup.Text>
               </InputGroup>
             </Col>

--- a/apps/frontend/src/hooks/use-http.ts
+++ b/apps/frontend/src/hooks/use-http.ts
@@ -16,6 +16,12 @@ const axiosInstance = axios.create({
   withCredentials: true
 });
 
+type Request = {
+  url: string,
+  method: string,
+  body?: any
+}
+
 const useHttp = () => {
   let appCtx = useContext(AppContext);
 
@@ -42,21 +48,23 @@ const useHttp = () => {
     });
   }, [appCtx]);
 
-  const sendRequestToSetStore = useCallback((setStoreFunction: any, method: string, url: string, ...reqBody: any[]) => {
+  const sendRequestToSetStore = useCallback((setStoreFunction: any, ...requests: Request[]) => {
     try {
-      let requests: Promise<AxiosResponse<any, any>>[];
+      let requestsPromise: Promise<AxiosResponse<any, any>>[];
 
-      if (reqBody.length > 0) {
-        requests = reqBody.map((body: any) => axiosInstance(url, { method: method, data: body }));
+      if (requests.length > 0) {
+        requestsPromise = requests.map((r: any) => axiosInstance(r.url, { method: r.method, data: r.body }));
       } else {
-        requests = [axiosInstance(url, { method: method, data: reqBody})];
+        requestsPromise = [axiosInstance(requests[0].url, { method: requests[0].method, data: requests[0].body})];
       }
 
-      Promise.all(requests)
+      Promise.all(requestsPromise)
         .then((responses: any[]) => {
           logger.info(responses);
-          if (url === '/shared/config') {
-            getFiatRate(responses[0].data.fiatUnit); // shared/config will always only have 1 response
+          for (let i = 0; i < requests.length; i++) {
+            if (requests[i].url === '/shared/config') {
+              getFiatRate(responses[0].data.fiatUnit); // shared/config will always only have 1 response
+            }
           }
 
           const combinedResponses = responses.map(response => ({ ...response.data, ...{ isLoading: false, error: null } }));
@@ -79,22 +87,30 @@ const useHttp = () => {
   const setAfterNodeInfo = useCallback((nodeInfo: any) => {
     sendRequestToSetStore(
       appCtx.setListChannels,
-      'post',
-      '/cln/call',
-      { 'method': isCompatibleVersion((nodeInfo.version || ''), '23.02') ? 'listpeerchannels' : 'listpeers', 'params': [] },
-      { 'method': 'listnodes', 'params': [] });
-      appCtx.setNodeInfo(nodeInfo);
+      {
+        method: 'post',
+        url: '/cln/call',
+        body: { 'method': isCompatibleVersion((nodeInfo.version || ''), '23.02') ? 'listpeerchannels' : 'listpeers', 'params': [] },
+      },
+      {
+        method: 'post',
+        url: '/cln/call',
+        body: { 'method': 'listnodes', 'params': [] }
+      }
+    );
+    appCtx.setNodeInfo(nodeInfo);
   }, [appCtx, sendRequestToSetStore]);
 
   const fetchData = useCallback(() => {
-    sendRequestToSetStore(setAfterNodeInfo, 'post', '/cln/call', { 'method': 'getinfo', 'params': [] });
-    sendRequestToSetStore(appCtx.setListPeers, 'post', '/cln/call', { 'method': 'listpeers', 'params': [] });
-    sendRequestToSetStore(appCtx.setListInvoices, 'post', '/cln/call', { 'method': 'listinvoices', 'params': [] });
-    sendRequestToSetStore(appCtx.setListPayments, 'post', '/cln/call', { 'method': 'listsendpays', 'params': [] });
-    sendRequestToSetStore(appCtx.setListFunds, 'post', '/cln/call', { 'method': 'listfunds', 'params': [] });
-    sendRequestToSetStore(appCtx.setListOffers, 'post', '/cln/call', { 'method': 'listoffers', 'params': [] });
-    sendRequestToSetStore(appCtx.setListBitcoinTransactions, 'post', '/cln/call', { 'method': 'bkpr-listaccountevents', 'params': [] });
-    sendRequestToSetStore(appCtx.setFeeRate, 'post', '/cln/call', { 'method': 'feerates', 'params': ['perkb'] });
+    sendRequestToSetStore(setAfterNodeInfo, { method: 'post', url: '/cln/call', body: { 'method': 'getinfo', 'params': [] } });
+    sendRequestToSetStore(appCtx.setListPeers, { method: 'post', url: '/cln/call', body: { 'method': 'listpeers', 'params': [] } });
+    sendRequestToSetStore(appCtx.setListInvoices, { method: 'post', url: '/cln/call', body: { 'method': 'listinvoices', 'params': [] } });
+    sendRequestToSetStore(appCtx.setListPayments, { method: 'post', url: '/cln/call', body: { 'method': 'listsendpays', 'params': [] } });
+    sendRequestToSetStore(appCtx.setListFunds, { method: 'post', url: '/cln/call', body: { 'method': 'listfunds', 'params': [] } });
+    sendRequestToSetStore(appCtx.setListOffers, { method: 'post', url: '/cln/call', body: { 'method': 'listoffers', 'params': [] } });
+    sendRequestToSetStore(appCtx.setListBitcoinTransactions, { method: 'post', url: '/cln/call', body: { 'method': 'bkpr-listaccountevents', 'params': [] } });
+    sendRequestToSetStore(appCtx.setFeeRate, { method: 'post', url: '/cln/call', body: { 'method': 'feerates', 'params': ['perkb'] } });
+    getConnectWallet();
   }, [appCtx, sendRequestToSetStore, setAfterNodeInfo]);
 
   const updateConfig = (updatedConfig: ApplicationConfiguration) => {
@@ -167,6 +183,10 @@ const useHttp = () => {
     return sendRequest(false, 'post', '/cln/call', { 'method': 'fetchinvoice', 'params': { 'offer': offer, 'amount_msat': amount * SATS_MSAT } });
   };
 
+  const createInvoiceRune = () => {
+    sendRequest(true, 'post', '/cln/call', { method: 'createrune', params: { restrictions: [["method=invoice"], ["method=listinvoices"]] } });
+  };
+
   const setCSRFToken = () => {
     return new Promise((resolve, reject) => {
       try {
@@ -186,11 +206,14 @@ const useHttp = () => {
   };
 
   const getAppConfigurations = useCallback(() => {
-    sendRequestToSetStore(appCtx.setConfig, 'get', '/shared/config');
+    sendRequestToSetStore(appCtx.setConfig, { method: 'get', url: '/shared/config' });
   }, [appCtx, sendRequestToSetStore]);
 
   const getConnectWallet = useCallback(() => {
-    sendRequestToSetStore(appCtx.setWalletConnect, 'get', '/shared/connectwallet');
+    sendRequestToSetStore(
+      appCtx.setWalletConnect, 
+      { method: 'get', url: '/shared/connectwallet' },
+      { method: 'post', url: '/cln/call', body: { method: 'showrunes' } });
   }, [appCtx, sendRequestToSetStore]);
 
   const userLogin = (password: string) => {
@@ -262,6 +285,7 @@ const useHttp = () => {
     clnReceiveInvoice,
     decodeInvoice,
     fetchInvoice,
+    createInvoiceRune,
     userLogin,
     resetUserPassword,
     userLogout

--- a/apps/frontend/src/types/app-config.type.ts
+++ b/apps/frontend/src/types/app-config.type.ts
@@ -4,6 +4,7 @@ export type ConnectWalletFields = {
   port: { title: string; field: string; }; // REST, Websocket or gRPC
   host: { title: string; field: string; };
   macaroon: { title: string; field: string; }; // Or ClientKey
+  invoiceRune: { title: string; field: string; };
   connectUrl: { title: string; field: string; };
   clientCert: { title: string; field: string; };
   caCert: { title: string; field: string; };
@@ -25,6 +26,7 @@ export type WalletConnect = {
   WS_PORT?: string;
   NODE_PUBKEY?: string;
   COMMANDO_RUNE?: string;
+  INVOICE_RUNE?: string;
   APP_VERSION?: string;
   error?: any;
 }

--- a/apps/frontend/src/types/app-context.type.ts
+++ b/apps/frontend/src/types/app-context.type.ts
@@ -1,5 +1,5 @@
 import { ApplicationConfiguration, FiatConfig, ModalConfig, ToastConfig, WalletConnect, AuthResponse } from './app-config.type';
-import { Fund, ListInvoices, ListPayments, ListPeers, ListBitcoinTransactions, NodeInfo, WalletBalances, ListLightningTransactions, NodeFeeRate, ListOffers, ListPeerChannels, ListNodes } from './lightning-wallet.type';
+import { Fund, ListInvoices, ListPayments, ListPeers, ListBitcoinTransactions, NodeInfo, WalletBalances, ListLightningTransactions, NodeFeeRate, ListOffers, ListPeerChannels, ListNodes, ShowRunes } from './lightning-wallet.type';
 
 export type AppContextType = {
   authStatus: AuthResponse;
@@ -22,7 +22,7 @@ export type AppContextType = {
   setAuthStatus: (newValue: AuthResponse) => void;
   setShowModals: (newShowModals: ModalConfig) => void;
   setShowToast: (newShowToast: ToastConfig) => void;
-  setWalletConnect: (newWalletConnect: WalletConnect) => void;
+  setWalletConnect: (data: (WalletConnect | ShowRunes)) => void;
   setConfig: (newAppConfig: ApplicationConfiguration) => void;
   setFiatConfig: (newFiatConfig: FiatConfig) => void;
   setFeeRate: (feeRate: NodeFeeRate) => void;

--- a/apps/frontend/src/types/lightning-wallet.type.ts
+++ b/apps/frontend/src/types/lightning-wallet.type.ts
@@ -462,3 +462,32 @@ export type Inflight = {
   our_funding_msat: string;
   scratch_txid?: string;
 }
+
+export type ShowRunes = {
+  runes: Rune[],
+  isLoading: boolean,
+  error?: any
+}
+
+export type Rune = {
+  rune: string;
+  unique_id: string;
+  restrictions: Restriction[];
+  restrictions_as_english: string;
+  stored?: boolean;
+  blacklisted?: boolean; 
+  last_used?: number;
+  our_rune?: boolean;
+}
+
+export type Restriction = {
+  alternatives: Alternative[];
+  english: string;
+}
+
+export type Alternative = {
+  fieldname: string;
+  value: string;
+  condition: string;
+  english: string;
+}

--- a/apps/frontend/src/utilities/test-utilities.tsx
+++ b/apps/frontend/src/utilities/test-utilities.tsx
@@ -195,6 +195,7 @@ export const mockStoreData = {
     CLN_NODE_IP: "127.0.0.1",
     NODE_PUBKEY: "03a389b3a2f7aa6f9f4ccc19f2bd7a2eba83596699e86b715caaaa147fc37f3144",
     COMMANDO_RUNE: "mRXhnFyVWrRQChA9eJ01RQT9W502daqrP0JA4BiHHw89MCZGb3IgQXBwbGljYXRpb24j",
+    INVOICE_RUNE: "aHFhnFyVWrRQChA9eJ01RQT9W502daqrP0JA4BiHHw89MCZGb3IgQXBwbGljYXRpb2==",
     APP_VERSION: "0.0.5",
     isLoading: false,
     error: null,


### PR DESCRIPTION
This commit adds an invoice rune to the ConnectWallet component.  Most values in that screen come from the backend method /shared/connectwallet and the type is found at app-config.type.ts/WalletConnect.

An invoice rune is added to WalletConnect because that is what is shown on the ConnectWallet.tsx component.  ApplicationActions.SET_WALLET_CONNECT appends an invoice rune if one is found.  If one is not found, ConnectWallet.tsx has a useEffect that checks for a missing invoice rune, and makes a createrune rpc call and then refreshes the component.